### PR TITLE
replication related fixes for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ VOLUME /var/lib/manticore /etc/sphinxsearch
 EXPOSE 9306
 EXPOSE 9308
 EXPOSE 9312
-EXPOSE 9315
-EXPOSE 9316
+EXPOSE 9315-9325
 CMD ["/usr/bin/searchd", "--nodetach", "--logreplication"]
 

--- a/sphinx.conf
+++ b/sphinx.conf
@@ -18,12 +18,12 @@ index pq {
 
 searchd {
     listen = 9306:mysql41
-    listen = 9312
+    listen = $ip:9312
     listen = 9308:http
     
     # more info about replication you can find at 
     # https://docs.manticoresearch.com/latest/html/replication.html
-    listen = $ip:9315
+    listen = $ip:9315-9325:replication
 
     log = /var/lib/manticore/log/searchd.log
 


### PR DESCRIPTION
missed points:

- API listener should have IP and not only ports
- replication listener should have ports range and replication protocol suffix
- docker file should expose all replication ports range