### PR TITLE
Fixed docker image to really work with MCL=1

### DIFF
--- a/building.md
+++ b/building.md
@@ -2,7 +2,7 @@
 
 ### Getting started
 
-We uses `docker buildx` for building our docker packages. To build new image:
+We use `docker buildx` for building our docker packages. To build new image:
 1) Check is `buildex` driver was already started, and re-run it in case check was failed:
   ```shell
     if [[ ! $(docker ps | grep manticore_build) ]]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -26,8 +26,9 @@ docker_setup_env() {
     [ ! -f /var/log/manticore/query.log ] && ln -sf /dev/stdout /var/log/manticore/query.log
   fi
 
+  MCL_DIR="/var/lib/manticore/.mcl/"
+
   if [[ "${EXTRA}" == "1" ]]; then
-    MCL_DIR="/var/lib/manticore/.mcl/"
     EXTRA_DIR="/var/lib/manticore/.extra/"
 
     if [ -f "${EXTRA_DIR}manticore-executor" ]; then


### PR DESCRIPTION
I noticed that docker image is crashing when MCL=1 is set without EXTRA=1 because of missing `mkdir` parameter (empty variable, because it's conditionally set).

This doesn't fix all the issues , as I'm getting this now:
```
manticore  | accepting connections
manticore  | WARNING: [BUDDY] invalid output, should be 'Buddy ver, started address:port', got '/usr/share/manticore/modules/manticore-buddy: line 12: echo: write error: Broken pipe
manticore  | '
manticore  | [BUDDY] restarting
manticore  | WARNING: [BUDDY] invalid output, should be 'Buddy ver, started address:port', got '/usr/share/manticore/modules/manticore-buddy: line 12: echo: write error: Broken pipe
manticore  | /usr/share/manticore/modules/manticore-buddy: line 13: /usr/bin/manticore-executor: Success
manticore  | '
manticore  | [BUDDY] restarting
manticore  | WARNING: [BUDDY] invalid output, should be 'Buddy ver, started address:port', got '/usr/share/manticore/modules/manticore-buddy: line 12: echo: write error: Broken pipe
manticore  | /usr/share/manticore/modules/manticore-buddy: line 13: /usr/bin/manticore-executor: Success
manticore  | '
manticore  | [BUDDY] restart amount of attempts (3) has been exceeded
```

But it runs and seems to work so that's a step forward :)