### PR TITLE
apt install tzdata in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN set -x \
     && mkdir /etc/ssl/ && touch /usr/bin/manticore-executor \
     && chown -R manticore:manticore /usr/bin/manticore-executor /etc/ssl/ \
     && chmod +x /usr/bin/manticore-executor \
-    && apt-get -y update && apt-get -y install --no-install-recommends ca-certificates binutils wget gnupg xz-utils dirmngr locales cron && rm -rf /var/lib/apt/lists/* \
+    && apt-get -y update && apt-get -y install --no-install-recommends ca-certificates binutils wget gnupg xz-utils dirmngr locales tzdata cron && rm -rf /var/lib/apt/lists/* \
     && locale-gen --lang en_US \
     && wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
     && wget -q -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \


### PR DESCRIPTION
Otherwise `manticore-tzdata` doesn't function properly since `/etc/localtime` doens't persist.